### PR TITLE
Fallback to templates for s3 gz url and baseDir

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -70,10 +70,21 @@ export default class UpdateCommand extends Command {
     await this.ensureClientDir()
     const output = path.join(this.clientRoot, version)
 
-    const {response: stream} = await http.stream(manifest.gz)
+    const gzUrl = manifest.gz || this.config.s3Url(this.config.s3Key('versioned', {
+      version,
+      channel,
+      bin: this.config.bin,
+      platform: this.config.platform,
+      arch: this.config.arch,
+      ext: 'gz'
+    }))
+    const {response: stream} = await http.stream(gzUrl)
     stream.pause()
 
-    let extraction = extract(stream, manifest.baseDir, output, manifest.sha256gz)
+    const baseDir = manifest.baseDir || this.config.s3Key('baseDir', {
+      bin: this.config.bin
+    })
+    let extraction = extract(stream, baseDir, output, manifest.sha256gz)
 
     // TODO: use cli.action.type
     if ((cli.action as any).frames) {


### PR DESCRIPTION
This change will allow us (sfdx) to continue to update in the style we were using under cli-engine, where the manifest did not contain the tarball download urls.  This is important to us since our staging s3 is hosted internally and we point the updater at the staging s3 using an environment variable.  When we promote a release to the public s3, we simply copy all tarballs, installers, and manifest from the internal s3 to the public one, so it works better for us to be able to derive the full update site urls at runtime rather than from the manifest files.
