### PR TITLE
Add full var set to basedir template renderer

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -82,7 +82,11 @@ export default class UpdateCommand extends Command {
     stream.pause()
 
     const baseDir = manifest.baseDir || this.config.s3Key('baseDir', {
-      bin: this.config.bin
+      version,
+      channel,
+      bin: this.config.bin,
+      platform: this.config.platform,
+      arch: this.config.arch,
     })
     let extraction = extract(stream, baseDir, output, manifest.sha256gz)
 


### PR DESCRIPTION
Trying to come up with a way to remain compatible with our existing v6 updater.