### PR TITLE
feat: use existing versions if available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /package-lock.json
 /tmp
 /oclif-plugin-update-*.tgz
+/.vscode

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -18,7 +18,7 @@ export default class UpdateCommand extends Command {
 
   static flags: flags.Input<any> = {
     autoupdate: flags.boolean({hidden: true}),
-    "to-existing-version": flags.string({description: "switch to an already installed version"}),
+    'to-existing-version': flags.string({description: 'switch to an already installed version'}),
   }
 
   private autoupdate!: boolean
@@ -43,7 +43,7 @@ export default class UpdateCommand extends Command {
 
     this.channel = args.channel || await this.determineChannel()
 
-    const pinToVersion = flags["to-existing-version"];
+    const pinToVersion = flags['to-existing-version']
     if (pinToVersion) {
       if (!await fs.pathExists(path.join(this.clientRoot, pinToVersion))) {
         throw new Error(`Version ${pinToVersion} is not already installed at ${this.clientRoot}.`)
@@ -51,7 +51,7 @@ export default class UpdateCommand extends Command {
       this.debug(`switching to existing version ${pinToVersion}`)
       this.updateToExistingVersion(pinToVersion)
 
-      this.log();
+      this.log()
       this.log(`Updating to an already installed version will not update the channel. If autoupdate is enabled, the CLI will eventually be updated back to ${this.channel}.`)
     } else {
       await this.config.runHook('preupdate', {channel: this.channel})

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -18,6 +18,7 @@ export default class UpdateCommand extends Command {
 
   static flags: flags.Input<any> = {
     autoupdate: flags.boolean({hidden: true}),
+    "to-existing-version": flags.string({description: "switch to an already installed version"}),
   }
 
   private autoupdate!: boolean
@@ -39,17 +40,32 @@ export default class UpdateCommand extends Command {
     if (this.autoupdate) await this.debounce()
 
     cli.action.start(`${this.config.name}: Updating CLI`)
+
     this.channel = args.channel || await this.determineChannel()
-    await this.config.runHook('preupdate', {channel: this.channel})
-    const manifest = await this.fetchManifest()
-    this.currentVersion = await this.determineCurrentVersion()
-    this.updatedVersion = (manifest as any).sha ? `${manifest.version}-${(manifest as any).sha}` : manifest.version
-    const reason = await this.skipUpdate()
-    if (reason) cli.action.stop(reason || 'done')
-    else await this.update(manifest)
-    this.debug('tidy')
-    await this.tidy()
-    await this.config.runHook('update', {channel: this.channel})
+
+    const pinToVersion = flags["to-existing-version"];
+    if (pinToVersion) {
+      if (!await fs.pathExists(path.join(this.clientRoot, pinToVersion))) {
+        throw new Error(`Version ${pinToVersion} is not already installed at ${this.clientRoot}.`)
+      }
+      this.debug(`switching to existing version ${pinToVersion}`)
+      this.updateToExistingVersion(pinToVersion)
+
+      this.log();
+      this.log(`Updating to an already installed version will not update the channel. If autoupdate is enabled, the CLI will eventually be updated back to ${this.channel}.`)
+    } else {
+      await this.config.runHook('preupdate', {channel: this.channel})
+      const manifest = await this.fetchManifest()
+      this.currentVersion = await this.determineCurrentVersion()
+      this.updatedVersion = (manifest as any).sha ? `${manifest.version}-${(manifest as any).sha}` : manifest.version
+      const reason = await this.skipUpdate()
+      if (reason) cli.action.stop(reason || 'done')
+      else await this.update(manifest)
+      this.debug('tidy')
+      await this.tidy()
+      await this.config.runHook('update', {channel: this.channel})
+    }
+
     this.debug('done')
     cli.action.stop()
   }
@@ -57,6 +73,7 @@ export default class UpdateCommand extends Command {
   private async fetchManifest(): Promise<IManifest> {
     const http: typeof HTTP = require('http-call').HTTP
 
+    cli.action.status = 'fetching manifest'
     if (!this.config.scopedEnvVarTrue('USE_LEGACY_UPDATE')) {
       try {
         const newManifestUrl = this.config.s3Url(
@@ -97,18 +114,15 @@ export default class UpdateCommand extends Command {
     }
   }
 
-  private async update(manifest: IManifest, channel = 'stable') {
-    const {version, channel: manifestChannel} = manifest
-    if (manifestChannel) channel = manifestChannel
-    cli.action.start(`${this.config.name}: Updating CLI from ${color.green(this.currentVersion)} to ${color.green(this.updatedVersion)}${channel === 'stable' ? '' : ' (' + color.yellow(channel) + ')'}`)
-    const http: typeof HTTP = require('http-call').HTTP
+  private async downloadAndExtract(output: string, manifest: IManifest, channel: string) {
+    const {version} = manifest
+
     const filesize = (n: number): string => {
       const [num, suffix] = require('filesize')(n, {output: 'array'})
       return num.toFixed(1) + ` ${suffix}`
     }
-    await this.ensureClientDir()
-    const output = path.join(this.clientRoot, this.updatedVersion)
 
+    const http: typeof HTTP = require('http-call').HTTP
     const gzUrl = manifest.gz || this.config.s3Url(this.config.s3Key('versioned', {
       version,
       channel,
@@ -149,11 +163,29 @@ export default class UpdateCommand extends Command {
 
     stream.resume()
     await extraction
+  }
+
+  private async update(manifest: IManifest, channel = 'stable') {
+    const {channel: manifestChannel} = manifest
+    if (manifestChannel) channel = manifestChannel
+    cli.action.start(`${this.config.name}: Updating CLI from ${color.green(this.currentVersion)} to ${color.green(this.updatedVersion)}${channel === 'stable' ? '' : ' (' + color.yellow(channel) + ')'}`)
+
+    await this.ensureClientDir()
+    const output = path.join(this.clientRoot, this.updatedVersion)
+
+    if (!await fs.pathExists(output)) {
+      await this.downloadAndExtract(output, manifest, channel)
+    }
 
     await this.setChannel()
     await this.createBin(this.updatedVersion)
     await this.touch()
     await this.reexec()
+  }
+
+  private async updateToExistingVersion(version: string) {
+    await this.createBin(version)
+    await this.touch()
   }
 
   private async skipUpdate(): Promise<string | false> {
@@ -279,7 +311,7 @@ export default class UpdateCommand extends Command {
       .on('error', reject)
       .on('close', (status: number) => {
         try {
-          this.exit(status)
+          if (status > 0) this.exit(status)
         } catch (error) {
           reject(error)
         }


### PR DESCRIPTION
If an existing version if it already exists. Now that channels are just pointers, I could switch to channels that point to the same version. If so, there is no need to download it again. Likewise, if a channel pointer is revered, there is no need to download it again.

In addition, if I run into a bug and I want to switch back to an older version of the CLI, there is not an easy way to switch back. Using `--from-local` will enable this capability.

![updatelocal](https://user-images.githubusercontent.com/918434/110996381-b4cdff00-8330-11eb-8f6c-f653a99e0a87.gif)

