### PR TITLE
fix: don't filter out node module binary symlinks

### DIFF
--- a/src/tar.ts
+++ b/src/tar.ts
@@ -34,14 +34,15 @@ export async function extract(stream: NodeJS.ReadableStream, basename: string, o
         })
       } else shaValidated = true
 
-      const ignore = (_: any, header: any) => {
+      const ignore = (name: string, header: any) => {
         switch (header.type) {
         case 'directory':
         case 'file':
           if (process.env.OCLIF_DEBUG_UPDATE_FILES) debug(header.name)
           return false
         case 'symlink':
-          return true
+          // If the binary is within node_modules/.bin, then we want to hold that symlink
+          return name.indexOf('node_modules/.bin') === -1;
         default:
           throw new Error(header.type)
         }

--- a/src/tar.ts
+++ b/src/tar.ts
@@ -42,7 +42,7 @@ export async function extract(stream: NodeJS.ReadableStream, basename: string, o
           return false
         case 'symlink':
           // If the binary is within node_modules/.bin, then we want to hold that symlink
-          return name.indexOf('node_modules/.bin') === -1;
+          return name.indexOf('node_modules/.bin') === -1
         default:
           throw new Error(header.type)
         }


### PR DESCRIPTION
Our team wraps `cypress` within our multi-cli. The Cypress API assumes a symlink exists from `node_modules/.bin` to `node_modules/cypress/bin/cypress`, and is throwing an error after we use this update plugin. We think the root cause is that node_modules/.bin linking has been filtered out of the tarball extraction.