### PR TITLE
Re-enable Github Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   ],
   "license": "MIT",
   "oclif": {
-    "autoupdate": "github",
     "commands": "./lib/commands",
     "bin": "oclif-example",
     "hooks": {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,15 +1,14 @@
-import color from '@oclif/color'
-import Command, {flags} from '@oclif/command'
-import {IManifest} from '@oclif/dev-cli'
-import cli from 'cli-ux'
-import * as spawn from 'cross-spawn'
-import * as fs from 'fs-extra'
-import HTTP from 'http-call'
-import * as _ from 'lodash'
 import * as path from 'path'
 
-import {extract} from '../tar'
-import {ls, wait} from '../util'
+import cli from 'cli-ux'
+import * as fs from 'fs-extra'
+
+import Command, {flags} from '@oclif/command'
+
+import LocalUpdater from '../local'
+import S3Updater from '../s3'
+import Updater from '../updater'
+import {wait} from '../util'
 
 export default class UpdateCommand extends Command {
   static description = 'update the <%= config.bin %> CLI'
@@ -23,15 +22,9 @@ export default class UpdateCommand extends Command {
 
   private autoupdate!: boolean
 
-  private channel!: string
+  channel!: string
 
-  private currentVersion?: string
-
-  private updatedVersion!: string
-
-  private readonly clientRoot = this.config.scopedEnvVar('OCLIF_CLIENT_HOME') || path.join(this.config.dataDir, 'client')
-
-  private readonly clientBin = path.join(this.clientRoot, 'bin', this.config.windows ? `${this.config.bin}.cmd` : this.config.bin)
+  private updater!: Updater
 
   async run() {
     const {args, flags} = this.parse(UpdateCommand)
@@ -42,220 +35,12 @@ export default class UpdateCommand extends Command {
     this.channel = args.channel || await this.determineChannel()
 
     if (flags['from-local']) {
-      await this.ensureClientDir()
-      this.debug(`Looking for locally installed versions at ${this.clientRoot}`)
-
-      // Do not show known non-local version folder names, bin and current.
-      const versions = fs.readdirSync(this.clientRoot).filter(dirOrFile => dirOrFile !== 'bin' && dirOrFile !== 'current')
-      if (versions.length === 0) throw new Error('No locally installed versions found.')
-
-      this.log(`Found versions: \n${versions.map(version => `     ${version}`).join('\n')}\n`)
-
-      const pinToVersion = await cli.prompt('Enter a version to update to')
-      if (!versions.includes(pinToVersion)) throw new Error(`Version ${pinToVersion} not found in the locally installed versions.`)
-
-      if (!await fs.pathExists(path.join(this.clientRoot, pinToVersion))) {
-        throw new Error(`Version ${pinToVersion} is not already installed at ${this.clientRoot}.`)
-      }
-      cli.action.start(`${this.config.name}: Updating CLI`)
-      this.debug(`switching to existing version ${pinToVersion}`)
-      this.updateToExistingVersion(pinToVersion)
-
-      this.log()
-      this.log(`Updating to an already installed version will not update the channel. If autoupdate is enabled, the CLI will eventually be updated back to ${this.channel}.`)
+      this.updater = new LocalUpdater(this, this.debug, this.log, this.warn)
     } else {
-      cli.action.start(`${this.config.name}: Updating CLI`)
-      await this.config.runHook('preupdate', {channel: this.channel})
-      const manifest = await this.fetchManifest()
-      this.currentVersion = await this.determineCurrentVersion()
-      this.updatedVersion = (manifest as any).sha ? `${manifest.version}-${(manifest as any).sha}` : manifest.version
-      const reason = await this.skipUpdate()
-      if (reason) cli.action.stop(reason || 'done')
-      else await this.update(manifest)
-      this.debug('tidy')
-      await this.tidy()
-      await this.config.runHook('update', {channel: this.channel})
+      this.updater = new S3Updater(this, this.debug, this.log, this.warn)
     }
 
-    this.debug('done')
-    cli.action.stop()
-  }
-
-  private async fetchManifest(): Promise<IManifest> {
-    const http: typeof HTTP = require('http-call').HTTP
-
-    cli.action.status = 'fetching manifest'
-    if (!this.config.scopedEnvVarTrue('USE_LEGACY_UPDATE')) {
-      try {
-        const newManifestUrl = this.config.s3Url(
-          this.s3ChannelManifestKey(
-            this.config.bin,
-            this.config.platform,
-            this.config.arch,
-            (this.config.pjson.oclif.update.s3 as any).folder,
-          ),
-        )
-        const {body} = await http.get<IManifest | string>(newManifestUrl)
-        if (typeof body === 'string') {
-          return JSON.parse(body)
-        }
-        return body
-      } catch (error) {
-        this.debug(error.message)
-      }
-    }
-
-    try {
-      const url = this.config.s3Url(this.config.s3Key('manifest', {
-        channel: this.channel,
-        platform: this.config.platform,
-        arch: this.config.arch,
-      }))
-      const {body} = await http.get<IManifest | string>(url)
-
-      // in case the content-type is not set, parse as a string
-      // this will happen if uploading without `oclif-dev publish`
-      if (typeof body === 'string') {
-        return JSON.parse(body)
-      }
-      return body
-    } catch (error) {
-      if (error.statusCode === 403) throw new Error(`HTTP 403: Invalid channel ${this.channel}`)
-      throw error
-    }
-  }
-
-  private async downloadAndExtract(output: string, manifest: IManifest, channel: string) {
-    const {version} = manifest
-
-    const filesize = (n: number): string => {
-      const [num, suffix] = require('filesize')(n, {output: 'array'})
-      return num.toFixed(1) + ` ${suffix}`
-    }
-
-    const http: typeof HTTP = require('http-call').HTTP
-    const gzUrl = manifest.gz || this.config.s3Url(this.config.s3Key('versioned', {
-      version,
-      channel,
-      bin: this.config.bin,
-      platform: this.config.platform,
-      arch: this.config.arch,
-      ext: 'gz',
-    }))
-    const {response: stream} = await http.stream(gzUrl)
-    stream.pause()
-
-    const baseDir = manifest.baseDir || this.config.s3Key('baseDir', {
-      version,
-      channel,
-      bin: this.config.bin,
-      platform: this.config.platform,
-      arch: this.config.arch,
-    })
-    const extraction = extract(stream, baseDir, output, manifest.sha256gz)
-
-    // to-do: use cli.action.type
-    if ((cli.action as any).frames) {
-      // if spinner action
-      const total = parseInt(stream.headers['content-length']!, 10)
-      let current = 0
-      const updateStatus = _.throttle(
-        (newStatus: string) => {
-          cli.action.status = newStatus
-        },
-        250,
-        {leading: true, trailing: false},
-      )
-      stream.on('data', data => {
-        current += data.length
-        updateStatus(`${filesize(current)}/${filesize(total)}`)
-      })
-    }
-
-    stream.resume()
-    await extraction
-  }
-
-  private async update(manifest: IManifest, channel = 'stable') {
-    const {channel: manifestChannel} = manifest
-    if (manifestChannel) channel = manifestChannel
-    cli.action.start(`${this.config.name}: Updating CLI from ${color.green(this.currentVersion)} to ${color.green(this.updatedVersion)}${channel === 'stable' ? '' : ' (' + color.yellow(channel) + ')'}`)
-
-    await this.ensureClientDir()
-    const output = path.join(this.clientRoot, this.updatedVersion)
-
-    if (!await fs.pathExists(output)) {
-      await this.downloadAndExtract(output, manifest, channel)
-    }
-
-    await this.setChannel()
-    await this.createBin(this.updatedVersion)
-    await this.touch()
-    await this.reexec()
-  }
-
-  private async updateToExistingVersion(version: string) {
-    await this.createBin(version)
-    await this.touch()
-  }
-
-  private async skipUpdate(): Promise<string | false> {
-    if (!this.config.binPath) {
-      const instructions = this.config.scopedEnvVar('UPDATE_INSTRUCTIONS')
-      if (instructions) this.warn(instructions)
-      return 'not updatable'
-    }
-    if (this.currentVersion === this.updatedVersion) {
-      if (this.config.scopedEnvVar('HIDE_UPDATED_MESSAGE')) return 'done'
-      return `already on latest version: ${this.currentVersion}`
-    }
-    return false
-  }
-
-  private async determineChannel(): Promise<string> {
-    const channelPath = path.join(this.config.dataDir, 'channel')
-    if (fs.existsSync(channelPath)) {
-      const channel = await fs.readFile(channelPath, 'utf8')
-      return String(channel).trim()
-    }
-    return this.config.channel || 'stable'
-  }
-
-  private async determineCurrentVersion(): Promise<string|undefined> {
-    try {
-      const currentVersion = await fs.readFile(this.clientBin, 'utf8')
-      const matches = currentVersion.match(/\.\.[/|\\](.+)[/|\\]bin/)
-      return matches ? matches[1] : this.config.version
-    } catch (error) {
-      this.debug(error)
-    }
-    return this.config.version
-  }
-
-  private s3ChannelManifestKey(bin: string, platform: string, arch: string, folder?: string): string {
-    let s3SubDir = folder || ''
-    if (s3SubDir !== '' && s3SubDir.slice(-1) !== '/') s3SubDir = `${s3SubDir}/`
-    return path.join(s3SubDir, 'channels', this.channel, `${bin}-${platform}-${arch}-buildmanifest`)
-  }
-
-  private async setChannel() {
-    const channelPath = path.join(this.config.dataDir, 'channel')
-    fs.writeFile(channelPath, this.channel, 'utf8')
-  }
-
-  private async logChop() {
-    try {
-      this.debug('log chop')
-      const logChopper = require('log-chopper').default
-      await logChopper.chop(this.config.errlog)
-    } catch (error) {
-      this.debug(error.message)
-    }
-  }
-
-  private async mtime(f: string) {
-    const {mtime} = await fs.stat(f)
-    return mtime
+    await this.updater.update()
   }
 
   // when autoupdating, wait until the CLI isn't active
@@ -278,112 +63,17 @@ export default class UpdateCommand extends Command {
     cli.log('time to update')
   }
 
-  // removes any unused CLIs
-  private async tidy() {
-    try {
-      const root = this.clientRoot
-      if (!await fs.pathExists(root)) return
-      const files = await ls(root)
-      const promises = files.map(async f => {
-        if (['bin', 'current', this.config.version].includes(path.basename(f.path))) return
-        const mtime = f.stat.mtime
-        mtime.setHours(mtime.getHours() + (42 * 24))
-        if (mtime < new Date()) {
-          await fs.remove(f.path)
-        }
-      })
-      for (const p of promises) await p // eslint-disable-line no-await-in-loop
-      await this.logChop()
-    } catch (error) {
-      cli.warn(error)
+  private async determineChannel(): Promise<string> {
+    const channelPath = path.join(this.config.dataDir, 'channel')
+    if (fs.existsSync(channelPath)) {
+      const channel = await fs.readFile(channelPath, 'utf8')
+      return String(channel).trim()
     }
+    return this.config.channel || 'stable'
   }
 
-  private async touch() {
-    // touch the client so it won't be tidied up right away
-    try {
-      const p = path.join(this.clientRoot, this.config.version)
-      this.debug('touching client at', p)
-      if (!await fs.pathExists(p)) return
-      await fs.utimes(p, new Date(), new Date())
-    } catch (error) {
-      this.warn(error)
-    }
-  }
-
-  private async reexec() {
-    cli.action.stop()
-    return new Promise((_, reject) => {
-      this.debug('restarting CLI after update', this.clientBin)
-      spawn(this.clientBin, ['update'], {
-        stdio: 'inherit',
-        env: {...process.env, [this.config.scopedEnvVarKey('HIDE_UPDATED_MESSAGE')]: '1'},
-      })
-      .on('error', reject)
-      .on('close', (status: number) => {
-        try {
-          if (status > 0) this.exit(status)
-        } catch (error) {
-          reject(error)
-        }
-      })
-    })
-  }
-
-  private async createBin(version: string) {
-    const dst = this.clientBin
-    const {bin} = this.config
-    const binPathEnvVar = this.config.scopedEnvVarKey('BINPATH')
-    const redirectedEnvVar = this.config.scopedEnvVarKey('REDIRECTED')
-    if (this.config.windows) {
-      const body = `@echo off
-setlocal enableextensions
-set ${redirectedEnvVar}=1
-set ${binPathEnvVar}=%~dp0${bin}
-"%~dp0..\\${version}\\bin\\${bin}.cmd" %*
-`
-      await fs.outputFile(dst, body)
-    } else {
-      /* eslint-disable no-useless-escape */
-      const body = `#!/usr/bin/env bash
-set -e
-get_script_dir () {
-  SOURCE="\${BASH_SOURCE[0]}"
-  # While $SOURCE is a symlink, resolve it
-  while [ -h "$SOURCE" ]; do
-    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-    SOURCE="$( readlink "$SOURCE" )"
-    # If $SOURCE was a relative symlink (so no "/" as prefix, need to resolve it relative to the symlink base directory
-    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
-  done
-  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-  echo "$DIR"
-}
-DIR=$(get_script_dir)
-${binPathEnvVar}="\$DIR/${bin}" ${redirectedEnvVar}=1 "$DIR/../${version}/bin/${bin}" "$@"
-`
-      /* eslint-enable no-useless-escape */
-
-      await fs.remove(dst)
-      await fs.outputFile(dst, body)
-      await fs.chmod(dst, 0o755)
-      await fs.remove(path.join(this.clientRoot, 'current'))
-      await fs.symlink(`./${version}`, path.join(this.clientRoot, 'current'))
-    }
-  }
-
-  private async ensureClientDir() {
-    try {
-      await fs.mkdirp(this.clientRoot)
-    } catch (error) {
-      if (error.code === 'EEXIST') {
-        // for some reason the client directory is sometimes a file
-        // if so, this happens. Delete it and recreate
-        await fs.remove(this.clientRoot)
-        await fs.mkdirp(this.clientRoot)
-      } else {
-        throw error
-      }
-    }
+  private async mtime(f: string) {
+    const {mtime} = await fs.stat(f)
+    return mtime
   }
 }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs-extra'
 
 import Command, {flags} from '@oclif/command'
 
+import GithubUpdater from '../github'
 import LocalUpdater from '../local'
 import S3Updater from '../s3'
 import Updater from '../updater'
@@ -36,6 +37,8 @@ export default class UpdateCommand extends Command {
 
     if (flags['from-local']) {
       this.updater = new LocalUpdater(this, this.debug, this.log, this.warn)
+    } else if ((this.config.pjson.oclif as any).autoupdate === 'github') {
+      this.updater = new GithubUpdater(this, this.debug, this.log, this.warn)
     } else {
       this.updater = new S3Updater(this, this.debug, this.log, this.warn)
     }

--- a/src/github.ts
+++ b/src/github.ts
@@ -7,7 +7,19 @@ import RemoteUpdater from './remote'
 export default class GithubUpdater extends RemoteUpdater {
   protected async fetchManifest(): Promise<IManifest> {
     const http: typeof HTTP = require('http-call').HTTP
-    const [owner, repo] = this.config.pjson.repository.split('/')
+
+    let owner
+    let repo
+    try {
+      const url = this.config.pjson.repository.url
+      const matches = url.match(/.+?:(.+?)\/(.+?)\.git/)
+      owner = matches[1]
+      repo = matches[2]
+    } catch (error) {
+      this.debug(error)
+      throw new Error('Github repository not defined')
+    }
+
     const {body} = await http.get(`https://api.github.com/repos/${owner}/${repo}/releases/latest`)
 
     if (typeof body === 'string') {

--- a/src/github.ts
+++ b/src/github.ts
@@ -41,7 +41,8 @@ export default class GithubUpdater extends RemoteUpdater {
 
   protected async initializeDownload(output: string, manifest: IManifest) {
     const {gz: gzUrl, baseDir} = manifest
-    await this.downloadAndExtract(output, gzUrl, baseDir)
+    const sha256gz: string | undefined = manifest.sha256gz === '' ? undefined : manifest.sha256gz
+    await this.downloadAndExtract(output, gzUrl, baseDir, sha256gz)
   }
 
   // Get the name of the manifest we are looking for - no channel support for now

--- a/src/github.ts
+++ b/src/github.ts
@@ -12,9 +12,14 @@ export default class GithubUpdater extends RemoteUpdater {
     let repo
     try {
       const url = this.config.pjson.repository.url
-      const matches = url.match(/.+?:(.+?)\/(.+?)\.git/)
-      owner = matches[1]
-      repo = matches[2]
+
+      if (url.includes('.git')) {
+        const matches = url.match(/(?:git\+ssh:\/\/)?.+?[:/](.+?)\/(.+?)\.git/)
+        owner = matches[1]
+        repo = matches[2]
+      } else {
+        throw new Error(`Repo url not in expected format: ${url}`)
+      }
     } catch (error) {
       this.debug(error)
       throw new Error('Github repository not defined')

--- a/src/github.ts
+++ b/src/github.ts
@@ -20,7 +20,7 @@ export default class GithubUpdater extends RemoteUpdater {
       throw new Error('Github repository not defined')
     }
 
-    const {body} = await http.get(`https://api.github.com/repos/${owner}/${repo}/releases/latest`)
+    const {body} = await http.get(`https://api.github.com/repos/${owner}/${repo}/releases/latest`, this.getReqHeaders())
 
     if (typeof body === 'string') {
       const release = JSON.parse(body)
@@ -60,5 +60,12 @@ export default class GithubUpdater extends RemoteUpdater {
   // Get the name of the manifest we are looking for - no channel support for now
   private getBinKey(bin: string, version: string, platform: string, arch: string): string {
     return `${bin}-${version}-${platform}-${arch}.tar.gz`
+  }
+
+  protected getReqHeaders(): {headers?: {Authorization?: string}} | undefined {
+    const token = this.config.scopedEnvVar('GITHUB_TOKEN')
+    if (token) {
+      return {headers: {Authorization: 'Bearer ' + token}}
+    }
   }
 }

--- a/src/local.ts
+++ b/src/local.ts
@@ -1,0 +1,40 @@
+import * as path from 'path'
+
+import cli from 'cli-ux'
+import * as fs from 'fs-extra'
+
+import Updater from './updater'
+
+export default class LocalUpdater extends Updater {
+  async update() {
+    await this.ensureClientDir()
+    this.debug(`Looking for locally installed versions at ${this.clientRoot}`)
+
+    // Do not show known non-local version folder names, bin and current.
+    const versions = fs.readdirSync(this.clientRoot).filter(dirOrFile => dirOrFile !== 'bin' && dirOrFile !== 'current')
+    if (versions.length === 0) throw new Error('No locally installed versions found.')
+
+    this.log(`Found versions: \n${versions.map(version => `     ${version}`).join('\n')}\n`)
+
+    const pinToVersion = await cli.prompt('Enter a version to update to')
+    if (!versions.includes(pinToVersion)) throw new Error(`Version ${pinToVersion} not found in the locally installed versions.`)
+
+    if (!await fs.pathExists(path.join(this.clientRoot, pinToVersion))) {
+      throw new Error(`Version ${pinToVersion} is not already installed at ${this.clientRoot}.`)
+    }
+
+    this.start()
+
+    this.debug(`Switching to existing version ${pinToVersion}`)
+    this.updateToExistingVersion(pinToVersion)
+
+    this.log(`\nUpdating to an already installed version will not update the channel. If autoupdate is enabled, the CLI will eventually be updated back to ${this.channel}.`)
+
+    this.stop()
+  }
+
+  private async updateToExistingVersion(version: string) {
+    await this.createBin(version)
+    await this.touch()
+  }
+}

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -1,0 +1,139 @@
+import * as path from 'path'
+
+import cli from 'cli-ux'
+import * as spawn from 'cross-spawn'
+import * as fs from 'fs-extra'
+
+import color from '@oclif/color'
+import {IManifest} from '@oclif/dev-cli'
+
+import Updater from './updater'
+import {ls} from './util'
+
+export default abstract class RemoteUpdater extends Updater {
+  private currentVersion?: string
+
+  private updatedVersion!: string
+
+  protected abstract fetchManifest(): Promise<IManifest>
+
+  protected abstract downloadAndExtract(output: string, manifest: IManifest, channel: string): void
+
+  async update() {
+    this.start()
+
+    await this.config.runHook('preupdate', {channel: this.channel})
+
+    const manifest = await this.fetchManifest()
+    this.currentVersion = await this.determineCurrentVersion()
+    this.updatedVersion = (manifest as any).sha ? `${manifest.version}-${(manifest as any).sha}` : manifest.version
+
+    const reason = await this.skipUpdate()
+    if (reason) cli.action.stop(reason || 'done')
+    else await this.installUpdate(manifest)
+
+    this.debug('tidy')
+    await this.tidy()
+
+    await this.config.runHook('update', {channel: this.channel})
+
+    this.stop()
+  }
+
+  private async installUpdate(manifest: IManifest, channel = 'stable') {
+    const {channel: manifestChannel} = manifest
+    if (manifestChannel) channel = manifestChannel
+    cli.action.start(`${this.config.name}: Updating CLI from ${color.green(this.currentVersion)} to ${color.green(this.updatedVersion)}${channel === 'stable' ? '' : ' (' + color.yellow(channel) + ')'}`)
+
+    await this.ensureClientDir()
+    const output = path.join(this.clientRoot, this.updatedVersion)
+
+    if (!await fs.pathExists(output)) {
+      await this.downloadAndExtract(output, manifest, channel)
+    }
+
+    await this.setChannel()
+    await this.createBin(this.updatedVersion)
+    await this.touch()
+    await this.reexec()
+  }
+
+  private async determineCurrentVersion(): Promise<string|undefined> {
+    try {
+      const currentVersion = await fs.readFile(this.clientBin, 'utf8')
+      const matches = currentVersion.match(/\.\.[/|\\](.+)[/|\\]bin/)
+      return matches ? matches[1] : this.config.version
+    } catch (error) {
+      this.debug(error)
+    }
+    return this.config.version
+  }
+
+  private async logChop() {
+    try {
+      this.debug('log chop')
+      const logChopper = require('log-chopper').default
+      await logChopper.chop(this.config.errlog)
+    } catch (error) {
+      this.debug(error.message)
+    }
+  }
+
+  private async reexec() {
+    cli.action.stop()
+    return new Promise((_, reject) => {
+      this.debug('restarting CLI after update', this.clientBin)
+      spawn(this.clientBin, ['update'], {
+        stdio: 'inherit',
+        env: {...process.env, [this.config.scopedEnvVarKey('HIDE_UPDATED_MESSAGE')]: '1'},
+      })
+      .on('error', reject)
+      .on('close', (status: number) => {
+        try {
+          if (status > 0) this.exit(status)
+        } catch (error) {
+          reject(error)
+        }
+      })
+    })
+  }
+
+  private async setChannel() {
+    const channelPath = path.join(this.config.dataDir, 'channel')
+    fs.writeFile(channelPath, this.channel, 'utf8')
+  }
+
+  private async skipUpdate(): Promise<string | false> {
+    if (!this.config.binPath) {
+      const instructions = this.config.scopedEnvVar('UPDATE_INSTRUCTIONS')
+      if (instructions) this.warn(instructions)
+      return 'not updatable'
+    }
+    if (this.currentVersion === this.updatedVersion) {
+      if (this.config.scopedEnvVar('HIDE_UPDATED_MESSAGE')) return 'done'
+      return `already on latest version: ${this.currentVersion}`
+    }
+    return false
+  }
+
+  // removes any unused CLIs
+  private async tidy() {
+    try {
+      const root = this.clientRoot
+      if (!await fs.pathExists(root)) return
+      const files = await ls(root)
+      const promises = files.map(async f => {
+        if (['bin', 'current', this.config.version].includes(path.basename(f.path))) return
+        const mtime = f.stat.mtime
+        mtime.setHours(mtime.getHours() + (42 * 24))
+        if (mtime < new Date()) {
+          await fs.remove(f.path)
+        }
+      })
+      for (const p of promises) await p // eslint-disable-line no-await-in-loop
+      await this.logChop()
+    } catch (error) {
+      cli.warn(error)
+    }
+  }
+}

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -22,6 +22,8 @@ export default abstract class RemoteUpdater extends Updater {
 
   protected abstract initializeDownload(output: string, manifest: IManifest): void
 
+  protected abstract getReqHeaders(): {headers?: {Authorization?: string}} | undefined
+
   async update() {
     this.start()
 
@@ -79,7 +81,7 @@ export default abstract class RemoteUpdater extends Updater {
     }
 
     const http: typeof HTTP = require('http-call').HTTP
-    const {response: stream} = await http.stream(gzUrl)
+    const {response: stream} = await http.stream(gzUrl, this.getReqHeaders())
     stream.pause()
 
     const extraction = extract(stream, baseDir, output, sha256gz)

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -78,4 +78,8 @@ export default class S3Updater extends RemoteUpdater {
     if (s3SubDir !== '' && s3SubDir.slice(-1) !== '/') s3SubDir = `${s3SubDir}/`
     return path.join(s3SubDir, 'channels', this.channel, `${bin}-${platform}-${arch}-buildmanifest`)
   }
+
+  protected getReqHeaders(): {headers?: {Authorization?: string}} | undefined {
+    return undefined
+  }
 }

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -2,12 +2,10 @@ import * as path from 'path'
 
 import cli from 'cli-ux'
 import HTTP from 'http-call'
-import {throttle} from 'lodash'
 
 import {IManifest} from '@oclif/dev-cli'
 
 import RemoteUpdater from './remote'
-import {extract} from './tar'
 
 export default class S3Updater extends RemoteUpdater {
   protected async fetchManifest(): Promise<IManifest> {
@@ -54,15 +52,9 @@ export default class S3Updater extends RemoteUpdater {
     }
   }
 
-  protected async downloadAndExtract(output: string, manifest: IManifest, channel: string) {
-    const {version} = manifest
-
-    const filesize = (n: number): string => {
-      const [num, suffix] = require('filesize')(n, {output: 'array'})
-      return num.toFixed(1) + ` ${suffix}`
-    }
-
-    const http: typeof HTTP = require('http-call').HTTP
+  protected async initializeDownload(output: string, manifest: IManifest) {
+    const {version, sha256gz} = manifest
+    const channel = this.channel
     const gzUrl = manifest.gz || this.config.s3Url(this.config.s3Key('versioned', {
       version,
       channel,
@@ -71,9 +63,6 @@ export default class S3Updater extends RemoteUpdater {
       arch: this.config.arch,
       ext: 'gz',
     }))
-    const {response: stream} = await http.stream(gzUrl)
-    stream.pause()
-
     const baseDir = manifest.baseDir || this.config.s3Key('baseDir', {
       version,
       channel,
@@ -81,28 +70,7 @@ export default class S3Updater extends RemoteUpdater {
       platform: this.config.platform,
       arch: this.config.arch,
     })
-    const extraction = extract(stream, baseDir, output, manifest.sha256gz)
-
-    // to-do: use cli.action.type
-    if ((cli.action as any).frames) {
-      // if spinner action
-      const total = parseInt(stream.headers['content-length']!, 10)
-      let current = 0
-      const updateStatus = throttle(
-        (newStatus: string) => {
-          cli.action.status = newStatus
-        },
-        250,
-        {leading: true, trailing: false},
-      )
-      stream.on('data', data => {
-        current += data.length
-        updateStatus(`${filesize(current)}/${filesize(total)}`)
-      })
-    }
-
-    stream.resume()
-    await extraction
+    await this.downloadAndExtract(output, gzUrl, baseDir, sha256gz)
   }
 
   private s3ChannelManifestKey(bin: string, platform: string, arch: string, folder?: string): string {

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -1,0 +1,113 @@
+import * as path from 'path'
+
+import cli from 'cli-ux'
+import HTTP from 'http-call'
+import {throttle} from 'lodash'
+
+import {IManifest} from '@oclif/dev-cli'
+
+import RemoteUpdater from './remote'
+import {extract} from './tar'
+
+export default class S3Updater extends RemoteUpdater {
+  protected async fetchManifest(): Promise<IManifest> {
+    const http: typeof HTTP = require('http-call').HTTP
+
+    cli.action.status = 'fetching manifest'
+    if (!this.config.scopedEnvVarTrue('USE_LEGACY_UPDATE')) {
+      try {
+        const newManifestUrl = this.config.s3Url(
+          this.s3ChannelManifestKey(
+            this.config.bin,
+            this.config.platform,
+            this.config.arch,
+            (this.config.pjson.oclif.update.s3 as any).folder,
+          ),
+        )
+        const {body} = await http.get<IManifest | string>(newManifestUrl)
+        if (typeof body === 'string') {
+          return JSON.parse(body)
+        }
+        return body
+      } catch (error) {
+        this.debug(error.message)
+      }
+    }
+
+    try {
+      const url = this.config.s3Url(this.config.s3Key('manifest', {
+        channel: this.channel,
+        platform: this.config.platform,
+        arch: this.config.arch,
+      }))
+      const {body} = await http.get<IManifest | string>(url)
+
+      // in case the content-type is not set, parse as a string
+      // this will happen if uploading without `oclif-dev publish`
+      if (typeof body === 'string') {
+        return JSON.parse(body)
+      }
+      return body
+    } catch (error) {
+      if (error.statusCode === 403) throw new Error(`HTTP 403: Invalid channel ${this.channel}`)
+      throw error
+    }
+  }
+
+  protected async downloadAndExtract(output: string, manifest: IManifest, channel: string) {
+    const {version} = manifest
+
+    const filesize = (n: number): string => {
+      const [num, suffix] = require('filesize')(n, {output: 'array'})
+      return num.toFixed(1) + ` ${suffix}`
+    }
+
+    const http: typeof HTTP = require('http-call').HTTP
+    const gzUrl = manifest.gz || this.config.s3Url(this.config.s3Key('versioned', {
+      version,
+      channel,
+      bin: this.config.bin,
+      platform: this.config.platform,
+      arch: this.config.arch,
+      ext: 'gz',
+    }))
+    const {response: stream} = await http.stream(gzUrl)
+    stream.pause()
+
+    const baseDir = manifest.baseDir || this.config.s3Key('baseDir', {
+      version,
+      channel,
+      bin: this.config.bin,
+      platform: this.config.platform,
+      arch: this.config.arch,
+    })
+    const extraction = extract(stream, baseDir, output, manifest.sha256gz)
+
+    // to-do: use cli.action.type
+    if ((cli.action as any).frames) {
+      // if spinner action
+      const total = parseInt(stream.headers['content-length']!, 10)
+      let current = 0
+      const updateStatus = throttle(
+        (newStatus: string) => {
+          cli.action.status = newStatus
+        },
+        250,
+        {leading: true, trailing: false},
+      )
+      stream.on('data', data => {
+        current += data.length
+        updateStatus(`${filesize(current)}/${filesize(total)}`)
+      })
+    }
+
+    stream.resume()
+    await extraction
+  }
+
+  private s3ChannelManifestKey(bin: string, platform: string, arch: string, folder?: string): string {
+    let s3SubDir = folder || ''
+    if (s3SubDir !== '' && s3SubDir.slice(-1) !== '/') s3SubDir = `${s3SubDir}/`
+    return path.join(s3SubDir, 'channels', this.channel, `${bin}-${platform}-${arch}-buildmanifest`)
+  }
+}

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -1,0 +1,119 @@
+import * as path from 'path'
+
+import cli from 'cli-ux'
+import * as fs from 'fs-extra'
+
+import {IConfig} from '@oclif/config'
+
+import UpdateCommand from './commands/update'
+
+export default abstract class Updater {
+  private readonly command!: UpdateCommand
+
+  protected readonly config!: IConfig
+
+  protected readonly debug: (...args: any[]) => void
+
+  protected readonly log: (...args: any[]) => void
+
+  protected readonly warn: (...args: any[]) => void
+
+  protected readonly channel = this.command.channel
+
+  protected readonly exit = this.command.exit
+
+  protected readonly name = this.command.config.name
+
+  protected readonly clientRoot = this.config.scopedEnvVar('OCLIF_CLIENT_HOME') || path.join(this.config.dataDir, 'client')
+
+  protected readonly clientBin = path.join(this.clientRoot, 'bin', this.config.windows ? `${this.config.bin}.cmd` : this.config.bin)
+
+  constructor(command: UpdateCommand, debug: (...args: any[]) => void, log: (...args: any[]) => void, warn: (...args: any[]) => void) {
+    this.command = command
+    this.config = command.config
+    this.debug = debug
+    this.log = log
+    this.warn = warn
+  }
+
+  abstract update(): void
+
+  protected start() {
+    cli.action.start(`${this.name}: Updating CLI`)
+  }
+
+  protected stop() {
+    this.debug('done')
+
+    cli.action.stop()
+  }
+
+  protected async createBin(version: string) {
+    const dst = this.clientBin
+    const {bin} = this.command.config
+    const binPathEnvVar = this.command.config.scopedEnvVarKey('BINPATH')
+    const redirectedEnvVar = this.command.config.scopedEnvVarKey('REDIRECTED')
+    if (this.command.config.windows) {
+      const body = `@echo off
+setlocal enableextensions
+set ${redirectedEnvVar}=1
+set ${binPathEnvVar}=%~dp0${bin}
+"%~dp0..\\${version}\\bin\\${bin}.cmd" %*
+`
+      await fs.outputFile(dst, body)
+    } else {
+      /* eslint-disable no-useless-escape */
+      const body = `#!/usr/bin/env bash
+set -e
+get_script_dir () {
+  SOURCE="\${BASH_SOURCE[0]}"
+  # While $SOURCE is a symlink, resolve it
+  while [ -h "$SOURCE" ]; do
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$( readlink "$SOURCE" )"
+    # If $SOURCE was a relative symlink (so no "/" as prefix, need to resolve it relative to the symlink base directory
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+  done
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  echo "$DIR"
+}
+DIR=$(get_script_dir)
+${binPathEnvVar}="\$DIR/${bin}" ${redirectedEnvVar}=1 "$DIR/../${version}/bin/${bin}" "$@"
+`
+      /* eslint-enable no-useless-escape */
+
+      await fs.remove(dst)
+      await fs.outputFile(dst, body)
+      await fs.chmod(dst, 0o755)
+      await fs.remove(path.join(this.clientRoot, 'current'))
+      await fs.symlink(`./${version}`, path.join(this.clientRoot, 'current'))
+    }
+  }
+
+  protected async ensureClientDir() {
+    try {
+      await fs.mkdirp(this.clientRoot)
+    } catch (error) {
+      if (error.code === 'EEXIST') {
+        // for some reason the client directory is sometimes a file
+        // if so, this happens. Delete it and recreate
+        await fs.remove(this.clientRoot)
+        await fs.mkdirp(this.clientRoot)
+      } else {
+        throw error
+      }
+    }
+  }
+
+  // touch the client so it won't be tidied up right away
+  protected async touch() {
+    try {
+      const p = path.join(this.clientRoot, this.command.config.version)
+      this.debug('Touching client at', p)
+      if (!await fs.pathExists(p)) return
+      await fs.utimes(p, new Date(), new Date())
+    } catch (error) {
+      this.warn(error)
+    }
+  }
+}

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -18,28 +18,30 @@ export default abstract class Updater {
 
   protected readonly warn: (...args: any[]) => void
 
-  protected readonly channel = this.command.channel
+  protected readonly exit: (...args: any[]) => void
 
-  protected readonly exit = this.command.exit
+  protected readonly channel: string
 
-  protected readonly name = this.command.config.name
+  protected readonly clientRoot: string
 
-  protected readonly clientRoot = this.config.scopedEnvVar('OCLIF_CLIENT_HOME') || path.join(this.config.dataDir, 'client')
-
-  protected readonly clientBin = path.join(this.clientRoot, 'bin', this.config.windows ? `${this.config.bin}.cmd` : this.config.bin)
+  protected readonly clientBin: string
 
   constructor(command: UpdateCommand, debug: (...args: any[]) => void, log: (...args: any[]) => void, warn: (...args: any[]) => void) {
     this.command = command
     this.config = command.config
+    this.channel = command.channel
+    this.exit = command.exit
     this.debug = debug
     this.log = log
     this.warn = warn
+    this.clientRoot = this.config.scopedEnvVar('OCLIF_CLIENT_HOME') || path.join(this.config.dataDir, 'client')
+    this.clientBin = path.join(this.clientRoot, 'bin', this.config.windows ? `${this.config.bin}.cmd` : this.config.bin)
   }
 
   abstract update(): void
 
   protected start() {
-    cli.action.start(`${this.name}: Updating CLI`)
+    cli.action.start(`${this.config.name}: Updating CLI`)
   }
 
   protected stop() {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,6 @@
-import * as fs from 'fs-extra'
 import * as path from 'path'
+
+import * as fs from 'fs-extra'
 
 export async function touch(p: string) {
   try {


### PR DESCRIPTION
For the purposes of supporting internal tools which cannot be hosted via S3, this PR proposes to add support for downloading release binaries from Github. This is in some ways a re-introduction of that functionality as it appears to have existed at some point in the past. I recognize this is a large update (primarily a refactor, net-new functionality is minimal) and would be happy to discuss further. Here's a breakdown of what is included:

- The codebase is refactored with minimal changes, moving code out of the command itself to make it easier to introduce new switching logic between local, s3, and github modes
- Support for finding and downloading release binaries from public github repos (without auth) is added
- Support for private github repos (via optional token auth)

Remaining tasks:

- Ensure functionality and add tests
  - The code is currently not fully tested, so this should be considered just a potential implementation proposal at the moment
  - The existing test is an integration test of s3 that I am unable to run
  - There is no existing test of the "local" functionality
  - There are no unit tests
  - For this particular change, there needs to be a new test (or tests) of the github functionality
- (optional) Add channel support to github?