### PR TITLE
fix: add main to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,5 +78,6 @@
     "postpack": "rm -f oclif.manifest.json",
     "version": "oclif readme && git add README.md",
     "build": "rm -rf lib && tsc"
-  }
+  },
+  "main": "lib/index.js"
 }


### PR DESCRIPTION
### What does this PR do?

Adds the `main` entry to the package.json in order to improve the performance of module resolution in oclif/core
