### PR TITLE
fix: use scopedEnvVarKeys for bin aliases

### DIFF
--- a/src/hooks/init.ts
+++ b/src/hooks/init.ts
@@ -28,8 +28,8 @@ export const init: Interfaces.Hook<'init'> = async function (opts) {
 
   const autoupdateEnv = {
     ...process.env,
-    [this.config.scopedEnvVarKey('TIMESTAMPS')]: '1',
-    [this.config.scopedEnvVarKey('SKIP_ANALYTICS')]: '1',
+    ...this.config.scopedEnvVarKeys('TIMESTAMPS').map(key => [key: '1']),
+    ...this.config.scopedEnvVarKeys('SKIP_ANALYTICS').map(key => [key: '1']),
   }
 
   async function autoupdateNeeded(): Promise<boolean> {


### PR DESCRIPTION
@W-13825184@
requires: https://github.com/oclif/core/pull/751