### PR TITLE
fix: add a blank line to be swallowed by the spinner

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -271,7 +271,12 @@ const mtime = async (f: string): Promise<Date> => (await stat(f)).mtime
 const notUpdatable = (config: Config): boolean => {
   if (!config.binPath) {
     const instructions = config.scopedEnvVar('UPDATE_INSTRUCTIONS')
-    if (instructions) ux.warn(instructions)
+    if (instructions) {
+      ux.warn(instructions)
+      // once the spinner stops, it'll eat this blank line
+      ux.log()
+    }
+
     return true
   }
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -274,6 +274,7 @@ const notUpdatable = (config: Config): boolean => {
     if (instructions) {
       ux.warn(instructions)
       // once the spinner stops, it'll eat this blank line
+      // https://github.com/oclif/core/issues/799
       ux.log()
     }
 


### PR DESCRIPTION
@W-14208351@

the spinner is still eating the last line printed before it stops... but to fix it in `plugin-update` we'll print a sacrificial line to be eaten by the spinner

https://github.com/oclif/core/issues/799