### PR TITLE
feat: show channel in --available table

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -38,9 +38,11 @@ export default class UpdateCommand extends Command {
     available: Flags.boolean({
       char: 'a',
       description: 'See available versions.',
+      exclusive: ['version', 'interactive'],
     }),
     force: Flags.boolean({
       description: 'Force a re-download of the requested version.',
+      exclusive: ['interactive', 'available'],
     }),
     interactive: Flags.boolean({
       char: 'i',
@@ -50,7 +52,7 @@ export default class UpdateCommand extends Command {
     version: Flags.string({
       char: 'v',
       description: 'Install a specific version.',
-      exclusive: ['interactive'],
+      exclusive: ['interactive', 'force'],
     }),
   }
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -36,7 +36,6 @@ export class Updater {
   }
 
   public async fetchVersionIndex(): Promise<VersionIndex> {
-    ux.action.status = 'fetching version index'
     const newIndexUrl = this.config.s3Url(s3VersionIndexKey(this.config))
     try {
       const {body} = await got.get<VersionIndex>(newIndexUrl)
@@ -83,6 +82,7 @@ export class Updater {
       if (localVersion) {
         await this.updateToExistingVersion(current, localVersion)
       } else {
+        ux.action.status = 'fetching version index'
         const index = await this.fetchVersionIndex()
         const url = index[version]
         if (!url) {


### PR DESCRIPTION
- Show `Channel` in the `update --available` table. 
- Show channel in `update --interactive` prompt

In both cases, we assume that `dist-tags` in npm correlate to what's in S3. Can be disabled with setting `oclif.update.disableNpmLookup` to true in CLI package.json

Fixes #674 

@W-15974839@