### PR TITLE
Add missing `index.ts`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,10 @@
+import CommandsUpdate from './commands/update.js'
+import {init} from './hooks/init.js'
+
+export const commands = {
+  update: CommandsUpdate,
+}
+
+export const hooks = {
+  init,
+}


### PR DESCRIPTION
The `package.json` has ` "exports": "./dist/index.js"`, but no actual `index.ts` or `index.js` exists.

This commit adds that file, in the same format as the one in `plugin-plugins`: https://github.com/oclif/plugin-plugins/blob/main/src/index.ts

This file is necessary for extending functionality of the `<cli> update` command by extending it. Prior to the ESM migration, this could have been done like so:
```typescript
import SuperUpdate from '@oclif/plugin-update/dist/commands/update'

export default class Update extends SuperUpdate {
```

With the change in this commit, this would now be done like so:
```typescript
import {commands} from '@oclif/plugin-update'

export default class Update extends commands['update'] {
```