### PR TITLE
feat: configure autoupdate frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,31 @@
 
 See https://oclif.io/docs/releasing.html#autoupdater
 
+## Configuration
+
+### Update Check Interval
+
+You can customize how often the plugin checks for updates by adding the `autoupdate.debounce` configuration to your `package.json`:
+
+```json
+{
+  "oclif": {
+    "update": {
+      "autoupdate": {
+        "debounce": 7
+      }
+    }
+  }
+}
+```
+
+The `debounce` value is the number of days between update checks for all channels. When set, it overrides the default behavior for all channels.
+
+If not configured, the plugin defaults to:
+
+- Stable channel: 14 days
+- Other channels: 1 day
+
 # Commands
 
 <!-- commands -->

--- a/src/hooks/init.ts
+++ b/src/hooks/init.ts
@@ -39,6 +39,13 @@ export const init: Interfaces.Hook<'init'> = async function (opts) {
       const m = await mtime(autoupdatefile)
       let days = 1
       if (opts.config.channel === 'stable') days = 14
+
+      // Check for custom update check interval in configuration
+      const debounce = config.pjson.oclif?.update?.autoupdate?.debounce
+      if (debounce !== undefined && debounce > 0) {
+        days = debounce
+      }
+
       m.setHours(m.getHours() + days * 24)
       return m < new Date()
     } catch (error: unknown) {


### PR DESCRIPTION
By default the autoupdate frequency is set to:

- 14 days for `stable` channel
- 1 day for other channels

We'd like to make that configurable (e.g. we want to use 1 day for all channels).

I noticed that there an `update.autoupdate` config type (with `debounce` and `rollout` properties). It seems unused today so I re-used the `debounce` once but I'm not sure it's the best naming/approach.

Would fix https://github.com/oclif/plugin-update/issues/1003