### PR TITLE
fix: avoid Node.js v24 DEP0190 deprecation warning

### DIFF
--- a/src/hooks/init.ts
+++ b/src/hooks/init.ts
@@ -76,7 +76,7 @@ export const init: Interfaces.Hook<'init'> = async function (opts) {
   )
 
   const stream = fd.createWriteStream()
-  spawn(binPath, ['update', '--autoupdate'], {
+  spawn(`${binPath} update --autoupdate`, {
     detached: !config.windows,
     env: autoupdateEnv,
     stdio: ['ignore', stream, stream],


### PR DESCRIPTION
https://nodejs.org/docs/latest-v24.x/api/deprecations.html#DEP0190
https://github.com/nodejs/help/issues/5063#issuecomment-3132899776
That's also how it was approached in angular-cli
https://github.com/angular/angular-cli/pull/30933/files