### PR TITLE
Make manifest URLs use oclif template config

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -375,7 +375,14 @@ const setChannel = async (channel: string, dataDir: string): Promise<void> =>
   writeFile(join(dataDir, 'channel'), channel, 'utf8')
 
 const fetchChannelManifest = async (channel: string, config: Config): Promise<Interfaces.S3Manifest> => {
-  const s3Key = s3ChannelManifestKey(channel, config)
+  const hasCustomTemplates = Boolean(config.pjson.oclif?.update?.s3?.templates)
+  const s3Key = hasCustomTemplates
+    ? config.s3Key('manifest', {
+        arch: config.arch,
+        channel,
+        platform: determinePlatform(config),
+      })
+    : s3ChannelManifestKey(channel, config)
   try {
     return await fetchManifest(s3Key, config)
   } catch (error: unknown) {


### PR DESCRIPTION
This is the first step towards fixing https://github.com/oclif/oclif/issues/828.

Actually releasing this might require a major bump. It only applies if the user has templates set in oclif -> update -> s3 -> templates, but if anybody has some of these leftover from older versions of Oclif when they were supported, and then updates this package, they will unexpectedly start fetching from a new location which will probably break their update mechanism entirely.

I would have assumed that was unlikely, but it turns out this even applies to the tests in this repo - they still have a [templates section](https://github.com/oclif/plugin-update/blame/main/examples/s3-update-example-cli/package.json#L45-L55) even though it hasn't been functional since Oclif v1, and so changing this code breaks all the nock mocking in the tests because the URL changes.

I'll open a parallel PR to update the publish-side code in just a minute as well.