### PR TITLE
fix: repository prefix devcenter links

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   ],
   "license": "MIT",
   "oclif": {
+    "repositoryPrefix": "<%- repo %>/blob/<%- version %>/<%- commandPath %>",
     "autoupdate": "github",
     "commands": "./dist/commands",
     "bin": "oclif-example",


### PR DESCRIPTION
## Description
adding repositoryPrefix so CLI command doc links point to this plugin’s repo and fix broken DevCenter links

## Related
[W-19690160](https://gus.lightning.force.com/a07EE00002M3HdRYAV)