### PR TITLE
fix: close autoupdate marker race in init hook

### DIFF
--- a/src/hooks/init.ts
+++ b/src/hooks/init.ts
@@ -2,7 +2,7 @@ import {Interfaces} from '@oclif/core'
 import makeDebug from 'debug'
 import {spawn} from 'node:child_process'
 import {existsSync} from 'node:fs'
-import {mkdir, open, stat, writeFile} from 'node:fs/promises'
+import {mkdir, open, stat, unlink, writeFile} from 'node:fs/promises'
 import {join} from 'node:path'
 
 import {touch} from '../util.js'
@@ -62,10 +62,24 @@ export const init: Interfaces.Hook<'init'> = async function (opts) {
   await touch(lastrunfile)
   const clientDir = join(clientRoot, config.version)
   if (existsSync(clientDir)) await touch(clientDir)
-  if (!(await autoupdateNeeded())) return
+
+  // Atomically claim the right to spawn an autoupdate.
+  //
+  // The original `if (!(await autoupdateNeeded())) return; await writeFile(...)`
+  // sequence had a non-atomic read-then-write window: several otto invocations
+  // starting in parallel on a machine with no marker file (e.g. a fresh
+  // laptop being set up) could all pass the autoupdateNeeded() check before
+  // any one of them wrote the marker, and each would spawn its own
+  // `<cli> update --autoupdate` child. Those children then pin in debounce()
+  // (which never exits while CLI activity continues) and accumulate until OOM.
+  //
+  // Fix: combine the check and the marker creation into a single atomic step
+  // using O_EXCL (`open(path, 'wx')`). Only one process can create the marker;
+  // others see EEXIST and bail (or, if the marker is stale, race to reclaim it
+  // — which is bounded to one race per debounce window per machine).
+  if (!(await claimAutoupdate(autoupdatefile))) return
 
   debug('autoupdate running')
-  await writeFile(autoupdatefile, '')
 
   debug(`spawning autoupdate on ${binPath}`)
 
@@ -85,4 +99,42 @@ export const init: Interfaces.Hook<'init'> = async function (opts) {
     .on('error', (e: Error) => process.emitWarning(e))
     .on('close', () => fd.close())
     .unref()
+
+  async function claimAutoupdate(markerPath: string): Promise<boolean> {
+    // Fast path: try to atomically create the marker. Wins the race when no
+    // marker exists yet (fresh-laptop case — the catastrophic scenario).
+    try {
+      const fd = await open(markerPath, 'wx')
+      await fd.close()
+      return true
+    } catch (error: unknown) {
+      const err = error as NodeJS.ErrnoException
+      if (err.code !== 'EEXIST') throw err
+    }
+
+    // Marker exists. If it's within the debounce window, nothing to do.
+    if (!(await autoupdateNeeded())) return false
+
+    // Marker is stale (debounce window has elapsed). Reclaim by unlinking and
+    // re-creating atomically. There remains a tiny window between unlink and
+    // open where two stale-marker processes could both win, but it's
+    // microseconds vs the multi-await window of the original bug, and
+    // bounded to one race per debounce window per machine.
+    try {
+      await unlink(markerPath)
+    } catch (error: unknown) {
+      const err = error as NodeJS.ErrnoException
+      if (err.code !== 'ENOENT') throw err
+    }
+
+    try {
+      const fd = await open(markerPath, 'wx')
+      await fd.close()
+      return true
+    } catch (error: unknown) {
+      const err = error as NodeJS.ErrnoException
+      if (err.code === 'EEXIST') return false
+      throw err
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Closes #1335 

The init hook in `src/hooks/init.ts` had a non-atomic check-and-write of the autoupdate marker file. This PR replaces that sequence with a single atomic claim using `open(path, 'wx')` (O_EXCL semantics).

## Bug

Before:

```ts
// src/hooks/init.ts (before)
if (!(await autoupdateNeeded())) return
debug('autoupdate running')
await writeFile(autoupdatefile, '')
// ... spawn `<cli> update --autoupdate` ...
```

Two awaits between the check and the write. When the marker file does not exist (`ENOENT → returns true`) or has expired the debounce window, N parallel CLI invocations all pass the check before any one writes the marker, and all N spawn their own autoupdate child.

After:

```ts
// src/hooks/init.ts (after)
if (!(await claimAutoupdate(autoupdatefile))) return
// ... spawn `<cli> update --autoupdate` ...
```

`claimAutoupdate` uses `open(markerPath, 'wx')` — POSIX-atomic. Only one process succeeds in creating the marker; others see `EEXIST`. If the marker exists but is stale (older than the debounce window), the function reclaims it by `unlink` + `open('wx')` — a microsecond-wide reclaim race remains, but it is bounded to one race per debounce window per machine, vs the previous multi-await window that opened on every fresh install or expiry.

## How to reproduce / verify

```bash
# 1. Simulate fresh-install:
rm -f ~/Library/Caches/<cli>/autoupdate

# 2. Fire several concurrent invocations:
for i in {1..6}; do <cli> --version >/dev/null 2>&1 & done; wait

# 3. Count surviving autoupdate children:
ps auxww | grep '<cli> update --autoupdate' | grep -v grep | wc -l
```

- Before this PR: typically equal to the number of concurrent invocations.
- With this PR: at most 1.

## What this PR does **not** claim

Fixing this race does NOT, by itself, prevent the per-spawned-child resource leak documented in the companion PR (`debounce()` recursion). One race-loser bails; one race-winner still spawns a child. That child can still pin in memory forever via the recursive sleep loop. The two PRs together close both halves of the autoupdate-flow leak; either alone is a partial fix.

## Test plan

- [x] All 9 existing tests pass (`yarn test`).
- [x] `yarn lint` clean.
- [ ] Add a unit test for `claimAutoupdate`'s atomic claim semantics (will follow if the approach is accepted).

## Open questions for reviewers

- **Should the stale-marker reclaim use `link(2)` for a true atomic swap** instead of `unlink` + `open('wx')`? Would close the microsecond reclaim race but adds platform-specific code. Happy to go either way.