### PR TITLE
fix: update bin script to load at once before execution

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -170,8 +170,12 @@ get_script_dir () {
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
   echo "$DIR"
 }
-DIR=$(get_script_dir)
-${binPathEnvVar}="\$DIR/${bin}" ${redirectedEnvVar}=1 "$DIR/../${version}/bin/${bin}" "$@"
+
+# Ensure everything is read at once before execution to avoid race conditions when updating versions
+{
+  DIR=$(get_script_dir)
+  ${binPathEnvVar}="\$DIR/${bin}" ${redirectedEnvVar}=1 "$DIR/../${version}/bin/${bin}" "$@"
+}; exit
 `
       /* eslint-enable no-useless-escape */
       await writeFile(dst, body, {mode: 0o755})


### PR DESCRIPTION
## Description

While working with Heroku CLI we have been observing the following Bash error when running a CLI update to a beta version:

> /opt/homebrew/Cellar/heroku/11.4.0/lib/client/bin/heroku: line 17: unexpected EOF while looking for matching `"'

After a lot of time investigating, we came to the conclusion that this happens because the script in the bin folder executing the `heroku update` invocation is the same that gets updated when the `createBin` function gets called.

Bash reads and executes commands one line at a time from disk. The last line of this script invokes another script from the currently active client CLI version, so by the time that shell command has finished executing and control returns to this Bash script, the update process modified the last line of the the script that now contains extra characters in it, because of the new version name being longer than the previous installed version. Those extra characters are read as if they were part from the original script and are interpreted as a (broken) shell command to be executed, triggering the error.

The correction just adds a block surrounding the script body, which forces Bash to load the whole thing into memory before executing it and avoids reading the extra characters added as another line to be executed.