### PR TITLE
fix: got downloadProgress undefined total

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -465,8 +465,8 @@ const downloadAndExtract = async (
     stream.on('downloadProgress', (progress) => {
       ux.action.status =
         progress.percent === 1
-          ? `${filesize(progress.transferred)}/${filesize(progress.total)} - Finishing up...`
-          : `${filesize(progress.transferred)}/${filesize(progress.total)}`
+          ? `${filesize(progress.transferred)}/${filesize(progress?.total || 0)} - Finishing up...`
+          : `${filesize(progress.transferred)}/${filesize(progress?.total || 0)}`
     })
   }
 


### PR DESCRIPTION
In 'got' the progress object total can be undefined. If undefined is passed to fileSize(...) it will throw an error. This change will send a 0 instead of undefined if total doesn't exist.

This was discovered due to a redirect from the gz download link that caused got to not have a "content-length" header for the first progress event, leaving total undefined.

resolves: #1348